### PR TITLE
Wait for test_submit_timeout() completion

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,8 @@ void test_submit_timeout() {
         wait_syncpoint(drm, syncpt, result.fence, 100);
     }
     catch (...) {
+        /* Wait for jobs timeout to avoid further tests failures */
+        wait_syncpoint(drm, syncpt, result.fence, DRM_TEGRA_NO_TIMEOUT);
         return;
     }
 


### PR DESCRIPTION
After submission, job would block channel for 10 seconds because we do not
specify jobs timeout value explicitly and kernel driver adjusts unspecified
value to 10 seconds by default. In order to avoid further tests failure
or invalid success due to a bogus timeout, let's wait for the syncpoint
increment that would happen after jobs timeout.