### PR TITLE
Clear governor in exception handler of performance test

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -287,6 +287,7 @@ void test_submit_performance(std::string& message) {
             governor.clear();
     }
     catch (...) {
+        governor.clear();
     }
 
     if (governor.empty())


### PR DESCRIPTION
In case of failure on writing to "scaling_governor", governor string needs
to be cleared to avoid exception on governor restore, this exception causes
a bogus perf test failure.