### PR TITLE
Speedup test_submit_timeout() completion

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -76,12 +76,23 @@ void test_submit_timeout(std::string& message) {
         wait_syncpoint(drm, syncpt, result.fence, 100);
     }
     catch (...) {
-        /* Wait for jobs timeout to avoid further tests failures */
-        wait_syncpoint(drm, syncpt, result.fence, DRM_TEGRA_NO_TIMEOUT);
-        return;
+        goto done;
     }
 
     throw std::runtime_error("Syncpoint wait did not timeout");
+
+done:
+    /* Jobs completion needs to be awaited in any case */
+    try {
+        /* Increment stalled syncpoint to speedup jobs completion */
+        incr_syncpoint(drm, syncpt);
+    }
+    catch (...) {
+        message += "Syncpoint increment failed!\n";
+    }
+
+    /* Wait for jobs completion to avoid further tests failures */
+    wait_syncpoint(drm, syncpt, result.fence, DRM_TEGRA_NO_TIMEOUT);
 }
 
 void test_invalid_cmdbuf(std::string& message) {

--- a/util.cpp
+++ b/util.cpp
@@ -151,6 +151,16 @@ void wait_syncpoint(DrmDevice &drm, uint32_t id, uint32_t threshold, uint32_t ti
         throw ioctl_error("Syncpoint wait failed");
 }
 
+void incr_syncpoint(DrmDevice &drm, uint32_t id) {
+    drm_tegra_syncpt_incr syncpt_incr_args;
+    memset(&syncpt_incr_args, 0, sizeof(syncpt_incr_args));
+    syncpt_incr_args.id = id;
+
+    int err = drm.ioctl(DRM_IOCTL_TEGRA_SYNCPT_INCR, &syncpt_incr_args);
+    if (err == -1)
+        throw ioctl_error("Syncpoint increment failed");
+}
+
 SubmitQuirks::SubmitQuirks()
 : force_cmdbuf_words(0)
 , force_cmdbuf_offset(0)

--- a/util.h
+++ b/util.h
@@ -76,6 +76,7 @@ public:
 };
 
 void wait_syncpoint(DrmDevice &drm, uint32_t id, uint32_t threshold, uint32_t timeout);
+void incr_syncpoint(DrmDevice &drm, uint32_t id);
 
 std::string read_file(const std::string& path);
 


### PR DESCRIPTION
To avoid waiting for jobs timeout, its stalled syncpoint could be incremented by CPU.