### PR TITLE
Preallocate command BO's in submission performance test

### DIFF
--- a/gem.cpp
+++ b/gem.cpp
@@ -56,6 +56,11 @@ GemBuffer::GemBuffer(DrmDevice &dev)
 {
 }
 
+GemBuffer::GemBuffer(const GemBuffer &gem)
+: _dev(gem._dev), _valid(false), _handle(0), _map(nullptr)
+{
+}
+
 GemBuffer::~GemBuffer()
 {
     if (_map) {

--- a/gem.h
+++ b/gem.h
@@ -46,7 +46,7 @@ typedef uint32_t gem_handle;
 class GemBuffer {
 public:
     GemBuffer(DrmDevice &dev);
-    GemBuffer(const GemBuffer &) = delete;
+    GemBuffer(const GemBuffer &);
     ~GemBuffer();
 
     int allocate(size_t bytes);

--- a/main.cpp
+++ b/main.cpp
@@ -220,25 +220,39 @@ float submit_performance_test(std::string& message, unsigned num_batches,
     unsigned i = 0, k;
 
     std::vector<GemBuffer> relocs;
+    std::vector<GemBuffer> cmdbufs;
 
-    for (k = 0; k < num_relocs; k++)
+    Submit::prepared_desc submit_descs[num_submits];
+
+    for (i = 0; i < num_relocs; i++)
         relocs.emplace_back(drm);
 
+    for (i = 0; i < num_submits; i++)
+        cmdbufs.emplace_back(drm);
+
+    uint32_t reloc_offset = 4;
     Submit submit;
     for (auto &bo : relocs) {
         if (bo.allocate(4096))
             throw std::runtime_error("Allocation failed");
 
+        submit.add_reloc(reloc_offset, bo.handle(), 0, 0);
         submit.push(host1x_opcode_nonincr(0x2b, 1));
         submit.push(0xdeadbeef);
+
+        reloc_offset += 8;
     }
     submit.push(host1x_opcode_nonincr(0, 1));
     submit.push(platform.incrementSyncpointOp(syncpt));
 
     submit.add_incr(syncpt, 1);
 
-    for (auto &bo : relocs)
-        submit.add_reloc(i++ * 8 + 4, bo.handle(), 0, 0);
+    for (auto &bo : cmdbufs)
+        if (bo.allocate(4096))
+            throw std::runtime_error("Allocation failed");
+
+    for (i = 0; i < num_submits; i++)
+        submit_descs[i] = submit.prepare(ch, cmdbufs[i]);
 
     clock_t clocks = 0;
 
@@ -247,7 +261,7 @@ float submit_performance_test(std::string& message, unsigned num_batches,
         clock_t begin = clock();
 
         for (k = 0; k < num_submits; k++)
-            result = submit.submit(ch);
+            result = submit.submit(ch, submit_descs[k]);
 
         clocks += clock() - begin;
         wait_syncpoint(drm, syncpt, result.fence, DRM_TEGRA_NO_TIMEOUT);

--- a/util.h
+++ b/util.h
@@ -70,6 +70,14 @@ public:
     void add_reloc(uint32_t cmdbuf_offset, uint32_t target,
                    uint32_t target_offset, uint32_t shift);
 
+    struct prepared_desc {
+        std::vector<drm_tegra_cmdbuf> cmdbufs;
+        std::vector<drm_tegra_syncpt> incrs;
+        std::vector<drm_tegra_reloc> relocs;
+    };
+
+    prepared_desc prepare(Channel &ch, GemBuffer &cmdbuf_bo);
+    drm_tegra_submit submit(Channel &ch, prepared_desc &prep_desc);
     drm_tegra_submit submit(Channel &ch);
 
     SubmitQuirks quirks;


### PR DESCRIPTION
Allocating BO might take substantial time, resulting in incorrect performance results.